### PR TITLE
chore: Remove deprecated @types/sharp package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@types/js-yaml": "^4.0.9",
         "@types/react": "^19.1.9",
         "@types/react-dom": "^19.1.7",
-        "@types/sharp": "^0.31.1",
         "astro": "^5.12.8",
         "discord.js": "^14.21.0",
         "dotenv": "^17.2.1",
@@ -2506,15 +2505,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
-      }
-    },
-    "node_modules/@types/sharp": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@types/sharp/-/sharp-0.31.1.tgz",
-      "integrity": "sha512-5nWwamN9ZFHXaYEincMSuza8nNfOof8nmO+mcI+Agx1uMUk4/pQnNIcix+9rLPXzKrm1pS34+6WRDbDV0Jn7ag==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/unist": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@types/js-yaml": "^4.0.9",
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
-    "@types/sharp": "^0.31.1",
     "astro": "^5.12.8",
     "discord.js": "^14.21.0",
     "dotenv": "^17.2.1",


### PR DESCRIPTION
## Summary
- Remove deprecated `@types/sharp` package from dependencies
- Sharp library now provides its own built-in TypeScript definitions
- Reduces unnecessary dependencies and follows current best practices

## Changes
- Removed `@types/sharp` from package.json and package-lock.json
- Verified that Sharp v0.34.3 includes native TypeScript definitions
- Confirmed all TypeScript compilation and builds work correctly

## Test plan
- [x] Build passes successfully (`npm run build`)
- [x] TypeScript compilation works without errors
- [x] Sharp functionality in `src/lib/srefs.ts` remains intact
- [x] Image dimension extraction continues working as expected

🤖 Generated with [Claude Code](https://claude.ai/code)