### PR TITLE
Major UI Refresh: dark‑mode polish, refined gallery, SEO + sitemap, Playwright E2E & CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,15 +35,12 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
 
-      - name: Cache system dependencies
-        uses: actions/cache@v4
-        id: playwright-deps-cache
-        with:
-          path: /var/cache/apt
-          key: ${{ runner.os }}-playwright-deps-${{ hashFiles('package-lock.json') }}
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install
 
-      - name: Install Playwright browsers and deps
-        run: npx playwright install --with-deps
+      - name: Install Playwright system dependencies
+        run: npx playwright install-deps
 
       - name: Build site
         run: npm run build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,43 @@
+name: E2E Tests
+
+on:
+  push:
+    branches:
+      - main
+      - feat/**
+  pull_request:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Install Playwright Browsers
+        uses: microsoft/playwright-github-action@v1
+
+      - name: Build site
+        run: npm run build
+
+      - name: Run Playwright tests
+        run: npx playwright test --reporter=html --trace=retain-on-failure
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+          retention-days: 7
+

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   e2e:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     timeout-minutes: 20
     steps:
       - name: Checkout

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,8 +4,9 @@ on:
   push:
     branches:
       - main
-      - feat/**
   pull_request:
+    branches:
+      - main
 
 jobs:
   e2e:
@@ -27,7 +28,21 @@ jobs:
       - name: Install deps
         run: npm ci
 
-      - name: Install Playwright (browsers + deps)
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+
+      - name: Cache system dependencies
+        uses: actions/cache@v4
+        id: playwright-deps-cache
+        with:
+          path: /var/cache/apt
+          key: ${{ runner.os }}-playwright-deps-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright browsers and deps
         run: npx playwright install --with-deps
 
       - name: Build site

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Install deps
         run: npm ci
 
-      - name: Install Playwright Browsers
-        uses: microsoft/playwright-github-action@v1
+      - name: Install Playwright (browsers + deps)
+        run: npx playwright install --with-deps
 
       - name: Build site
         run: npm run build
@@ -43,4 +43,3 @@ jobs:
           name: playwright-report
           path: playwright-report
           retention-days: 7
-

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,13 +1,14 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
+import sitemap from '@astrojs/sitemap';
 import tailwindcss from '@tailwindcss/vite';
 
 // https://astro.build/config
 export default defineConfig({
   site: 'https://srefdb.com',
   base: '/',
-  integrations: [react()],
+  integrations: [react(), sitemap()],
   vite: {
     plugins: [tailwindcss()]
   }

--- a/e2e/explore-before.spec.ts
+++ b/e2e/explore-before.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Explore button ::before is disabled', () => {
+  test('no ::before content or background (dark)', async ({ page }) => {
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await page.goto('/');
+    const button = page.getByRole('link', { name: /Explore gallery/i });
+    await expect(button).toBeVisible();
+
+    const before = await button.evaluate((el) => {
+      const s = getComputedStyle(el as HTMLElement, '::before');
+      return {
+        content: s.content,
+        backgroundImage: s.backgroundImage,
+      };
+    });
+
+    await button.hover();
+    await page.waitForTimeout(100);
+
+    const after = await button.evaluate((el) => {
+      const s = getComputedStyle(el as HTMLElement, '::before');
+      return {
+        content: s.content,
+        backgroundImage: s.backgroundImage,
+      };
+    });
+
+    // Expect no pseudo background before and after hover
+    const isNone = (v: string) => v === 'none' || v === '""' || v === 'normal';
+    expect(isNone(before.content)).toBeTruthy();
+    expect(before.backgroundImage).toBe('none');
+
+    expect(isNone(after.content)).toBeTruthy();
+    expect(after.backgroundImage).toBe('none');
+  });
+});

--- a/e2e/explore-hover.spec.ts
+++ b/e2e/explore-hover.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Explore button hover (dark mode)', () => {
+  test('hover adds visible ring/shadow', async ({ page }) => {
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await page.goto('/');
+
+    const button = page.getByRole('link', { name: /Explore gallery/i });
+    await expect(button).toBeVisible();
+
+    const before = await button.evaluate((el) => {
+      const s = window.getComputedStyle(el as HTMLElement);
+      return { boxShadow: s.boxShadow, filter: s.filter, outlineWidth: s.outlineWidth };
+    });
+
+    await button.hover();
+    await page.waitForTimeout(150);
+
+    const after = await button.evaluate((el) => {
+      const s = window.getComputedStyle(el as HTMLElement);
+      return { boxShadow: s.boxShadow, filter: s.filter, outlineWidth: s.outlineWidth };
+    });
+
+    // We expect some visual delta on hover, at least box-shadow or outline width
+    expect(
+      after.boxShadow !== before.boxShadow || after.filter !== before.filter
+    ).toBeTruthy();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@astrojs/react": "^4.3.0",
+        "@astrojs/sitemap": "^3.4.2",
         "@tailwindcss/vite": "^4.1.11",
         "@types/js-yaml": "^4.0.9",
         "@types/react": "^19.1.9",
@@ -26,6 +27,7 @@
         "tsx": "^4.20.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.54.2",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "^16.3.0",
@@ -127,6 +129,17 @@
         "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
         "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.4.2.tgz",
+      "integrity": "sha512-wfN2dZzdkto6yaMtOFa/J9gc60YE3wl3rgSBoNJ+MU3lJVUMsDY9xf9uAVi8Mp/zEQKFDSJlQzBvqQUpw0Hf6g==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^8.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^3.24.4"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -1580,6 +1593,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.29",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
@@ -2507,6 +2536,15 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -2846,6 +2884,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -6363,6 +6407,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -6821,6 +6912,12 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "license": "ISC"
+    },
     "node_modules/scheduler": {
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
@@ -6970,6 +7067,31 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-8.0.0.tgz",
+      "integrity": "sha512-+AbdxhM9kJsHtruUF39bwS/B0Fytw6Fr1o4ZAIAEqA6cke2xcoO2GleBw9Zw7nRzILVEgz7zBM5GiTJjie1G9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^17.0.5",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "sitemap": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/sitemap/node_modules/@types/node": {
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+      "license": "MIT"
+    },
     "node_modules/smol-toml": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.4.1.tgz",
@@ -7013,6 +7135,12 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
       "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
       "license": "MIT"
     },
     "node_modules/string-width": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
     "bot:dev": "tsx watch src/bot/index.ts",
     "bot:start": "tsx src/bot/index.ts",
     "test": "vitest",
@@ -17,6 +19,7 @@
   },
   "dependencies": {
     "@astrojs/react": "^4.3.0",
+    "@astrojs/sitemap": "^3.4.2",
     "@tailwindcss/vite": "^4.1.11",
     "@types/js-yaml": "^4.0.9",
     "@types/react": "^19.1.9",
@@ -33,6 +36,7 @@
     "tsx": "^4.20.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.54.2",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'e2e',
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  retries: 0,
+  fullyParallel: true,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://localhost:4321',
+    headless: true,
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'npm run preview -- --port 4321',
+    port: 4321,
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/public/og.png
+++ b/public/og.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2ee96a0d61fab8e3d9be6cdc8f7dcabdec932cf7f9f97e92629c084fee723a6
+size 70

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://srefdb.com/sitemap-index.xml

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -60,6 +60,7 @@ export default function Search({ items, onResults }: SearchProps) {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search srefs by title, ID, or description..."
+          aria-label="Search srefs by title, ID, or description"
           className="w-full px-4 py-2 pr-10 text-gray-900 bg-white/90 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent dark:bg-white/10 dark:text-gray-100 dark:placeholder-gray-400 dark:border-white/10"
         />
         <svg

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -60,7 +60,7 @@ export default function Search({ items, onResults }: SearchProps) {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Search srefs by title, ID, or description..."
-          className="w-full px-4 py-2 pr-10 text-gray-900 bg-white border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          className="w-full px-4 py-2 pr-10 text-gray-900 bg-white/90 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent dark:bg-white/10 dark:text-gray-100 dark:placeholder-gray-400 dark:border-white/10"
         />
         <svg
           className="absolute right-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400"
@@ -85,9 +85,14 @@ export default function Search({ items, onResults }: SearchProps) {
               onClick={() => toggleTag(tag)}
               className={`px-3 py-1 text-sm font-medium rounded-full transition-colors ${
                 selectedTags.includes(tag)
-                  ? 'bg-blue-500 text-white'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                  ? 'text-white'
+                  : 'chip'
               }`}
+              style={{
+                background: selectedTags.includes(tag)
+                  ? 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)'
+                  : undefined
+              }}
             >
               {tag}
             </button>

--- a/src/components/SearchClient.tsx
+++ b/src/components/SearchClient.tsx
@@ -79,6 +79,7 @@ export default function SearchClient({ items }: SearchClientProps) {
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder="Search srefs by title, ID, or description..."
+              aria-label="Search srefs by title, ID, or description"
               className="w-full px-6 py-4 bg-white/80 text-gray-900 placeholder-gray-600 text-lg rounded-lg focus:outline-none focus:bg-white border-0 dark:bg-white/10 dark:text-gray-100 dark:placeholder-gray-400 dark:focus:bg-white/10"
             />
             <div className="absolute right-4 top-1/2 transform -translate-y-1/2 p-2 bg-gradient-to-r from-indigo-500 to-purple-500 rounded-lg shadow-lg dark:from-indigo-400/80 dark:to-purple-400/80">

--- a/src/components/SearchClient.tsx
+++ b/src/components/SearchClient.tsx
@@ -72,16 +72,16 @@ export default function SearchClient({ items }: SearchClientProps) {
       {/* Enhanced Search Interface */}
       <div className="relative max-w-2xl mx-auto">
         <div className="relative group">
-          <div className="absolute inset-0 bg-gradient-to-r from-indigo-500/20 to-purple-500/20 rounded-xl blur-xl group-hover:blur-2xl transition-all duration-300"></div>
+          <div className="absolute inset-0 bg-gradient-to-r from-indigo-500/20 to-purple-500/20 rounded-xl blur-xl group-hover:blur-2xl transition-all duration-300 dark:opacity-60"></div>
           <div className="relative glass rounded-xl p-1">
             <input
               type="text"
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder="Search srefs by title, ID, or description..."
-              className="w-full px-6 py-4 bg-white/80 text-gray-900 placeholder-gray-600 text-lg rounded-lg focus:outline-none focus:bg-white border-0"
+              className="w-full px-6 py-4 bg-white/80 text-gray-900 placeholder-gray-600 text-lg rounded-lg focus:outline-none focus:bg-white border-0 dark:bg-white/10 dark:text-gray-100 dark:placeholder-gray-400 dark:focus:bg-white/10"
             />
-            <div className="absolute right-4 top-1/2 transform -translate-y-1/2 p-2 bg-gradient-to-r from-indigo-500 to-purple-500 rounded-lg shadow-lg">
+            <div className="absolute right-4 top-1/2 transform -translate-y-1/2 p-2 bg-gradient-to-r from-indigo-500 to-purple-500 rounded-lg shadow-lg dark:from-indigo-400/80 dark:to-purple-400/80">
               <svg
                 className="w-5 h-5 text-white"
                 fill="none"
@@ -103,7 +103,7 @@ export default function SearchClient({ items }: SearchClientProps) {
       {/* Enhanced Tag Filters */}
       <div className="space-y-6">{allTags.length > 0 && (
         <div className="text-center">
-          <h3 className="text-lg font-semibold text-gray-700 mb-4">Filter by Style</h3>
+          <h3 className="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-4">Filter by Style</h3>
           <div className="flex flex-wrap justify-center gap-3">
             {allTags.map(tag => (
               <button
@@ -112,7 +112,7 @@ export default function SearchClient({ items }: SearchClientProps) {
                 className={`relative px-4 py-2 text-sm font-medium rounded-full transition-all duration-200 transform hover:scale-105 ${
                   selectedTags.includes(tag)
                     ? 'text-white shadow-lg'
-                    : 'text-gray-700 bg-white/60 border border-gray-200/60 hover:shadow-md hover:bg-white/80'
+                    : 'text-gray-700 dark:text-gray-200 bg-white/60 dark:bg-white/5 border border-gray-200/60 dark:border-white/10 hover:shadow-md hover:bg-white/80 dark:hover:bg-white/10'
                 }`}
                 style={{
                   background: selectedTags.includes(tag) 
@@ -200,20 +200,20 @@ export default function SearchClient({ items }: SearchClientProps) {
                     </div>
                   </div>
                   
-                  <div className="p-6 bg-white/95">
+                  <div className="p-6 bg-white/95 dark:bg-slate-900/40">
                     <div className="flex items-start justify-between gap-3 mb-3">
-                      <h3 className="text-lg font-bold text-slate-900 group-hover:text-indigo-600 transition-colors duration-200 leading-tight">
+                      <h3 className="text-lg font-bold text-slate-900 dark:text-slate-200 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors duration-200 leading-tight">
                         {item.title}
                       </h3>
                       <div className="flex-shrink-0">
-                        <code className="text-xs font-mono bg-indigo-50 text-indigo-800 px-3 py-1.5 rounded-full border border-indigo-200">
+                        <code className="text-xs font-mono bg-indigo-50 text-indigo-800 dark:bg-indigo-900/40 dark:text-indigo-200/90 px-3 py-1.5 rounded-full border border-indigo-200 dark:border-indigo-800/60">
                           {item.id}
                         </code>
                       </div>
                     </div>
                     
                     {item.description && (
-                      <p className="text-sm text-slate-700 mb-4 leading-relaxed line-clamp-2">
+                      <p className="text-sm text-slate-700 dark:text-slate-400 mb-4 leading-relaxed line-clamp-2">
                         {item.description}
                       </p>
                     )}
@@ -222,13 +222,13 @@ export default function SearchClient({ items }: SearchClientProps) {
                       {item.tags.slice(0, 3).map((tag) => (
                         <span 
                           key={tag} 
-                          className="inline-block px-3 py-1 text-xs font-medium text-slate-700 bg-slate-50 border border-slate-300 rounded-full hover:bg-indigo-50 hover:border-indigo-200 hover:text-indigo-600 transition-all duration-200 cursor-pointer"
+                          className="chip hover:bg-indigo-50 hover:border-indigo-200 hover:text-indigo-700 dark:hover:bg-indigo-900/20 dark:hover:border-indigo-800/60 dark:hover:text-indigo-300 transition-all duration-200 cursor-pointer"
                         >
                           {tag}
                         </span>
                       ))}
                       {item.tags.length > 3 && (
-                        <span className="inline-block px-3 py-1 text-xs font-medium text-slate-600 bg-slate-50 border border-slate-300 rounded-full">
+                        <span className="chip">
                           +{item.tags.length - 3} more
                         </span>
                       )}

--- a/src/components/SrefCard.astro
+++ b/src/components/SrefCard.astro
@@ -11,33 +11,34 @@ export interface Props {
 const { id, title, description, tags, coverImageUrl, path } = Astro.props;
 ---
 
-<article class="group relative bg-white/70 dark:bg-gray-800/70 backdrop-blur-sm rounded-lg overflow-hidden shadow-md hover:shadow-xl transition-shadow duration-300">
+<article class="group relative card overflow-hidden">
   <a href={path} class="block">
-    <div class="aspect-[4/3] overflow-hidden bg-gray-100">
+    <div class="aspect-[4/3] overflow-hidden bg-gray-100 relative">
       <img
         src={coverImageUrl}
         alt={title}
         loading="lazy"
-        class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+        class="w-full h-full object-cover group-hover:scale-110 transition-transform duration-500 ease-out"
       />
+      <div class="absolute inset-0 bg-gradient-to-t from-black/20 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
     </div>
-    <div class="p-4">
+    <div class="p-5 bg-white/95 dark:bg-transparent">
       <div class="flex items-start justify-between gap-2 mb-2">
-        <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
+        <h3 class="text-lg font-semibold text-gray-900 dark:text-slate-200 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors leading-tight">
           {title}
         </h3>
-        <code class="text-xs text-gray-500 dark:text-gray-400 font-mono bg-gray-200/60 dark:bg-gray-600/60 px-2 py-1 rounded">
+        <code class="text-xs font-mono bg-indigo-50 text-indigo-800 dark:bg-indigo-900/40 dark:text-indigo-200 px-2.5 py-1 rounded-full border border-indigo-200/80 dark:border-indigo-800/60">
           {id}
         </code>
       </div>
       {description && (
-        <p class="text-sm text-gray-600 dark:text-gray-300 mb-3 line-clamp-2">
+        <p class="text-sm text-gray-600 dark:text-slate-400 mb-3 leading-relaxed line-clamp-2">
           {description}
         </p>
       )}
-      <div class="flex flex-wrap gap-1">
+      <div class="flex flex-wrap gap-2">
         {tags.map((tag) => (
-          <span class="inline-block px-2 py-1 text-xs font-medium text-gray-600 dark:text-gray-300 bg-gray-200/50 dark:bg-gray-600/50 rounded-full">
+          <span class="chip">
             {tag}
           </span>
         ))}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,55 +2,62 @@
 export interface Props {
   title: string;
   description?: string;
+  ogTitle?: string;
+  ogDescription?: string;
+  ogImage?: string;
 }
 
-const { title, description = 'A collection of Midjourney style references' } = Astro.props;
+const { title, description = 'A collection of Midjourney style references', ogTitle, ogDescription, ogImage } = Astro.props;
+const pageUrl = Astro.url?.href ?? '';
+const site = Astro.site?.toString() ?? '';
+const canonical = pageUrl || site;
+const defaultOgImage = new URL('og.png', Astro.site ?? Astro.url).toString();
+const metaOgTitle = ogTitle ?? title;
+const metaOgDescription = ogDescription ?? description;
+const metaOgImage = ogImage ?? defaultOgImage;
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang="en" class="antialiased">
   <head>
     <meta charset="UTF-8" />
     <meta name="description" content={description} />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="icon" type="image/svg+xml" href={import.meta.env.BASE_URL + 'favicon.svg'} />
     <title>{title}</title>
+    <link rel="canonical" href={canonical} />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Sref Gallery" />
+    <meta property="og:title" content={metaOgTitle} />
+    <meta property="og:description" content={metaOgDescription} />
+    <meta property="og:url" content={canonical} />
+    <meta property="og:image" content={metaOgImage} />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content={metaOgTitle} />
+    <meta name="twitter:description" content={metaOgDescription} />
+    <meta name="twitter:image" content={metaOgImage} />
   </head>
-  <body class="min-h-screen bg-gradient-to-br from-white via-purple-50/30 to-blue-50/30 dark:from-gray-900 dark:via-purple-900/20 dark:to-blue-900/20 relative">
+  <body class="min-h-screen bg-gradient-to-br from-white via-purple-50/30 to-blue-50/30 dark:from-gray-950 dark:via-indigo-950/30 dark:to-slate-950/30 relative selection:bg-indigo-200/60 selection:text-slate-900">
     <!-- Background Pattern -->
     <div class="fixed inset-0 opacity-20" style="background: var(--bg-pattern);"></div>
     
-    <header class="relative glass border-b border-white/20 dark:border-white/10 backdrop-blur-xl">
-      <div class="container mx-auto px-4 py-6">
+    <header class="relative glass border-b border-white/20 dark:border-white/10 backdrop-blur-xl/2">
+      <div class="container mx-auto px-4 py-4">
         <nav class="flex items-center justify-between">
-          <a href={import.meta.env.BASE_URL} class="group relative">
-            <h1 class="text-3xl font-bold">
-              <span class="relative bg-gradient-to-r from-indigo-600 via-purple-600 to-pink-600 bg-clip-text text-transparent">
-                Sref Gallery
-                <div class="absolute -bottom-1 left-0 w-0 h-0.5 bg-gradient-to-r from-indigo-500 to-purple-500 group-hover:w-full transition-all duration-300"></div>
-              </span>
+          <a href={import.meta.env.BASE_URL} class="group relative inline-flex items-center gap-2">
+            <div class="w-8 h-8 rounded-xl bg-gradient-to-tr from-indigo-500 via-purple-500 to-pink-500 shadow-[0_0_0_3px_rgba(255,255,255,0.6)] dark:shadow-[0_0_0_3px_rgba(0,0,0,0.4)]"></div>
+            <h1 class="text-2xl md:text-3xl font-extrabold tracking-tight">
+              <span class="relative bg-gradient-to-r from-indigo-600 via-purple-600 to-pink-600 bg-clip-text text-transparent">Sref Gallery</span>
             </h1>
           </a>
-          <div class="flex items-center gap-6">
-            <a href={import.meta.env.BASE_URL} class="relative text-gray-800 dark:text-gray-200 hover:text-indigo-600 dark:hover:text-indigo-400 font-medium transition-colors group">
-              Browse
-              <div class="absolute -bottom-1 left-0 w-0 h-0.5 bg-gradient-to-r from-indigo-500 to-purple-500 group-hover:w-full transition-all duration-300"></div>
-            </a>
-            <a href={import.meta.env.BASE_URL + 'about'} class="relative text-gray-800 dark:text-gray-200 hover:text-indigo-600 dark:hover:text-indigo-400 font-medium transition-colors group">
-              About
-              <div class="absolute -bottom-1 left-0 w-0 h-0.5 bg-gradient-to-r from-indigo-500 to-purple-500 group-hover:w-full transition-all duration-300"></div>
-            </a>
-            <a 
-              href="https://github.com/jtatum/srefs" 
-              target="_blank" 
-              rel="noopener noreferrer"
-              class="relative text-gray-800 dark:text-gray-200 hover:text-indigo-600 dark:hover:text-indigo-400 font-medium transition-colors group inline-flex items-center gap-1.5"
-            >
-              <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-                <path fill-rule="evenodd" d="M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z" clip-rule="evenodd"></path>
-              </svg>
-              <span>Edit on GitHub</span>
-              <div class="absolute -bottom-1 left-0 w-0 h-0.5 bg-gradient-to-r from-indigo-500 to-purple-500 group-hover:w-full transition-all duration-300"></div>
+          <div class="flex items-center gap-2 sm:gap-4">
+            <a href={import.meta.env.BASE_URL} class="nav-link">Browse</a>
+            <a href={import.meta.env.BASE_URL + 'about'} class="nav-link">About</a>
+            <a href="https://github.com/jtatum/srefs" target="_blank" rel="noopener noreferrer" class="nav-link inline-flex items-center gap-1.5">
+              <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z" clip-rule="evenodd"></path></svg>
+              <span>GitHub</span>
             </a>
           </div>
         </nav>
@@ -78,4 +85,47 @@ const { title, description = 'A collection of Midjourney style references' } = A
 
 <style is:global>
   @import '../styles/global.css';
+  .nav-link {
+    position: relative;
+    color: rgb(31 41 55);
+    transition: color 150ms;
+    font-weight: 600;
+    letter-spacing: .01em;
+  }
+  @media (prefers-color-scheme: dark) {
+    .nav-link { color: rgba(255,255,255,0.86); text-shadow: 0 1px 2px rgba(0,0,0,.55); }
+  }
+  /* Keep text color stable on hover; rely on rainbow underline */
+  .nav-link:hover { color: inherit; }
+  .nav-link::after {
+    content: '';
+    position: absolute;
+    left: 0; bottom: -4px;
+    height: 2px; width: 0;
+    background: linear-gradient(90deg, #6366f1, #8b5cf6, #a855f7, #ec4899);
+    transition: width .25s ease;
+  }
+  .nav-link:hover::after { width: 100%; }
+
+  /* Prevent layout shift when dark mode toggles */
+  html { color-scheme: light dark; }
+
+  /* Tweak container width */
+  .container { max-width: 110rem; }
 </style>
+
+<script>
+  // Mark active nav link for a11y
+  (function(){
+    try {
+      const links = document.querySelectorAll('header nav a[href]');
+      const current = window.location.pathname.replace(/\/$/, '') || '/';
+      links.forEach((a) => {
+        const hrefPath = new URL((a as HTMLAnchorElement).href, window.location.origin).pathname.replace(/\/$/, '') || '/';
+        if (hrefPath === current) {
+          (a as HTMLElement).setAttribute('aria-current', 'page');
+        }
+      });
+    } catch {}
+  })();
+  </script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,20 +11,24 @@ const searchIndex = buildSearchIndex(srefs);
   <!-- Hero Section -->
   <div class="relative mb-16 text-center">
     <div class="mb-8">
-      <h1 class="text-5xl md:text-7xl font-bold mb-6">
-        <span class="bg-gradient-to-r from-indigo-600 via-purple-600 to-pink-600 bg-clip-text text-transparent leading-tight block">
-          Style Reference
-        </span>
-        <span class="text-gray-800 block">Gallery</span>
-      </h1>
+      <div class="relative inline-block">
+        <h1 class="text-5xl md:text-7xl font-extrabold mb-6 leading-[1.05] tracking-tight">
+          <span class="bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 dark:from-indigo-300 dark:via-purple-300 dark:to-pink-300 bg-clip-text text-transparent block drop-shadow-[0_1px_6px_rgba(0,0,0,0.35)]">Style Reference</span>
+          <span class="bg-gradient-to-r from-sky-500 via-cyan-500 to-emerald-500 dark:from-sky-300 dark:via-cyan-300 dark:to-emerald-300 bg-clip-text text-transparent block drop-shadow-[0_1px_6px_rgba(0,0,0,0.35)]">Gallery</span>
+        </h1>
+      </div>
       <div class="max-w-2xl mx-auto">
-        <p class="text-xl text-gray-700 leading-relaxed mb-8">
+        <p class="text-xl text-gray-700 dark:text-gray-300 leading-relaxed mb-8">
           Discover, browse, and collect 
           <span class="font-semibold bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent">
             Midjourney style references
           </span>. 
           Each sref unlocks unique artistic possibilities for your AI creations.
         </p>
+        <div class="flex items-center justify-center gap-3">
+          <a href="#explore" class="btn transition shadow-md hover:shadow-lg hover:-translate-y-0.5 dark:!bg-slate-900/90 dark:!text-slate-200 dark:!border-white/30 dark:hover:!bg-slate-900/95 dark:hover:!text-slate-100 dark:hover:ring-2 dark:hover:ring-indigo-400/60 dark:hover:ring-offset-2 dark:hover:ring-offset-slate-950 dark:hover:drop-shadow-[0_0_16px_rgba(99,102,241,0.28)]">Explore gallery</a>
+          <a href={import.meta.env.BASE_URL + 'about'} class="inline-flex items-center text-sm font-medium text-indigo-600 dark:text-indigo-400 hover:underline">Learn more</a>
+        </div>
       </div>
     </div>
     
@@ -34,5 +38,6 @@ const searchIndex = buildSearchIndex(srefs);
     <div class="absolute bottom-8 left-1/3 w-24 h-24 bg-gradient-to-br from-blue-400/20 to-cyan-400/20 rounded-full blur-xl"></div>
   </div>
 
-  <SearchClient client:load items={searchIndex} />
+  <div id="explore"></div>
+  <SearchClient client:idle items={searchIndex} />
 </Layout>

--- a/src/pages/sref/[id].astro
+++ b/src/pages/sref/[id].astro
@@ -16,9 +16,17 @@ const { sref } = Astro.props as { sref: ProcessedSref };
 if (!sref) {
   return Astro.redirect('/404');
 }
+const cover = sref.coverImageUrl || (sref.processedImages && sref.processedImages[0]?.url) || '';
+const ogImage = cover ? new URL(cover, Astro.site || Astro.url).toString() : undefined;
 ---
 
-<Layout title={`${sref.title} - Sref ${sref.id}`} description={sref.description}>
+<Layout 
+  title={`${sref.title} - Sref ${sref.id}`} 
+  description={sref.description}
+  ogTitle={`${sref.title} – Sref ${sref.id}`}
+  ogDescription={sref.description}
+  ogImage={ogImage}
+>
   <div class="max-w-7xl mx-auto">
     <!-- Enhanced Header Section -->
     <div class="relative mb-12">
@@ -30,17 +38,17 @@ if (!sref) {
         <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-6 mb-6">
           <div class="flex-1">
             <div class="flex items-center gap-3 mb-4">
-              <h1 class="text-4xl lg:text-5xl font-bold bg-gradient-to-r from-indigo-600 via-purple-600 to-pink-600 bg-clip-text text-transparent leading-tight">
+              <h1 class="text-4xl lg:text-5xl font-bold bg-gradient-to-r from-indigo-600 via-purple-600 to-pink-600 dark:from-indigo-300 dark:via-purple-300 dark:to-pink-300 bg-clip-text text-transparent leading-tight">
                 {sref.title}
               </h1>
               <div class="flex-shrink-0">
-                <code class="text-sm font-mono bg-gradient-to-r from-indigo-50 to-purple-50 text-indigo-700 px-4 py-2 rounded-full border border-indigo-200">
+                <code class="text-sm font-mono bg-gradient-to-r from-indigo-50 to-purple-50 text-indigo-700 px-4 py-2 rounded-full border border-indigo-200 dark:bg-indigo-900/40 dark:text-indigo-200 dark:border-indigo-800/60">
                   --sref {sref.id}
                 </code>
               </div>
             </div>
             {sref.description && (
-              <p class="text-xl text-gray-700 leading-relaxed max-w-3xl">
+              <p class="text-xl text-gray-700 dark:text-gray-300 leading-relaxed max-w-3xl">
                 {sref.description}
               </p>
             )}
@@ -63,7 +71,7 @@ if (!sref) {
           </button>
           
           {sref.created && (
-            <div class="flex items-center gap-2 text-sm text-gray-500">
+            <div class="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
               <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
               </svg>
@@ -79,10 +87,10 @@ if (!sref) {
       
       {sref.tags.length > 0 && (
         <div class="mt-8">
-          <h3 class="text-lg font-semibold text-gray-800 mb-4">Style Tags</h3>
+          <h3 class="text-lg font-semibold text-gray-800 dark:text-slate-200 mb-4">Style Tags</h3>
           <div class="flex flex-wrap gap-3">
             {sref.tags.map((tag) => (
-              <span class="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-full hover:border-indigo-200 hover:text-indigo-600 hover:bg-gray-50 transition-all duration-200">
+              <span class="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-full hover:border-indigo-200 hover:text-indigo-600 hover:bg-gray-50 transition-all duration-200 dark:text-slate-200 dark:bg-white/10 dark:border-white/15 dark:hover:bg-white/15 dark:hover:border-indigo-800/60">
                 <svg class="w-3 h-3 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
                 </svg>
@@ -96,7 +104,7 @@ if (!sref) {
 
     <!-- Enhanced Image Gallery -->
     <div class="mb-8">
-      <h2 class="text-2xl font-bold text-gray-800 mb-6">Example Images</h2>
+      <h2 class="text-2xl font-bold text-gray-800 dark:text-slate-200 mb-6">Example Images</h2>
     </div>
     
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
@@ -142,12 +150,12 @@ if (!sref) {
             {image.prompt && (
               <div class="p-6">
                 <div class="flex items-start gap-3">
-                  <div class="flex-shrink-0 p-2 bg-gradient-to-r from-indigo-50 to-purple-50 rounded-lg">
-                    <svg class="w-4 h-4 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <div class="flex-shrink-0 p-2 bg-gradient-to-r from-indigo-50 to-purple-50 rounded-lg dark:from-indigo-900/30 dark:to-purple-900/30">
+                    <svg class="w-4 h-4 text-indigo-600 dark:text-indigo-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
                     </svg>
                   </div>
-                  <p class="text-sm text-gray-700 font-mono leading-relaxed flex-1">
+                  <p class="text-sm text-gray-700 dark:text-slate-300 font-mono leading-relaxed flex-1">
                     {image.prompt}
                   </p>
                 </div>
@@ -163,7 +171,7 @@ if (!sref) {
       <div class="text-center">
         <a 
           href={import.meta.env.BASE_URL} 
-          class="group inline-flex items-center gap-3 px-6 py-3 bg-white border border-gray-300 rounded-xl hover:border-indigo-200 text-gray-700 hover:text-indigo-600 transition-all duration-200 hover:shadow-md hover:bg-gray-50"
+          class="group inline-flex items-center gap-3 px-6 py-3 bg-white border border-gray-300 rounded-xl hover:border-indigo-200 text-gray-700 hover:text-indigo-600 transition-all duration-200 hover:shadow-md hover:bg-gray-50 dark:bg-white/5 dark:border-white/15 dark:text-slate-200 dark:hover:bg-white/10 dark:hover:border-indigo-800/60"
         >
           <svg class="w-5 h-5 transition-transform group-hover:-translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -13,6 +13,10 @@
   --primary-700: #4338ca;
   --primary-800: #3730a3;
   --primary-900: #312e81;
+  --accent-500: #a855f7;
+  --pink-500: #ec4899;
+  --slate-900: #0f172a;
+  --slate-50: #f8fafc;
   
   /* Creative Gradients */
   --gradient-primary: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
@@ -29,6 +33,10 @@
   --shadow-medium: 0 4px 25px -3px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   --shadow-large: 0 10px 40px -4px rgba(0, 0, 0, 0.15), 0 4px 25px -5px rgba(0, 0, 0, 0.1);
   --shadow-colored: 0 8px 32px rgba(79, 70, 229, 0.15);
+
+  /* Radii & Insets */
+  --radius-lg: 16px;
+  --ring: linear-gradient(90deg, rgba(99,102,241,.45), rgba(168,85,247,.45));
 }
 
 /* Dark mode support */
@@ -43,6 +51,7 @@
 body {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
   font-feature-settings: 'cv02', 'cv03', 'cv04', 'cv11';
+  letter-spacing: 0.01em;
 }
 
 /* Enhanced Scrollbar */
@@ -105,21 +114,78 @@ input:focus-visible {
 
 /* Glass effect with better readability */
 .glass {
-  background: rgba(255, 255, 255, 0.98);
-  backdrop-filter: blur(12px);
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(14px) saturate(120%);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  box-shadow: 0 12px 40px rgba(2, 6, 23, 0.12);
 }
 
 @media (prefers-color-scheme: dark) {
   .glass {
-    background: rgba(15, 15, 15, 0.98);
-    border: 1px solid rgba(255, 255, 255, 0.15);
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+    background: rgba(10, 10, 12, 0.9);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    box-shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
   }
   
   /* Ensure text is readable in dark mode */
-  body {
-    color: rgb(229, 231, 235);
-  }
+  body { color: rgb(203, 213, 225); }
 }
+
+/* Card with gradient ring and subtle lift */
+.card {
+  position: relative;
+  background: rgba(255,255,255,0.98);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  transition: transform .25s ease, box-shadow .25s ease, border-color .25s ease;
+  border: 1px solid rgba(2,6,23,0.06);
+}
+.dark .card {
+  background: rgba(15, 15, 18, 0.98);
+  border-color: rgba(255,255,255,0.08);
+}
+.card::before {
+  content: '';
+  position: absolute; inset: -1px;
+  border-radius: calc(var(--radius-lg) + 1px);
+  background: var(--ring);
+  opacity: 0; filter: blur(8px);
+  transition: opacity .25s ease, filter .25s ease;
+  z-index: -1;
+}
+.card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-medium);
+}
+.card:hover::before { opacity: .9; filter: blur(14px); }
+
+/* Chips */
+.chip {
+  display: inline-block;
+  padding: 6px 10px;
+  font-size: 12px;
+  border-radius: 999px;
+  background: rgba(2,6,23,0.04);
+  color: rgb(71 85 105);
+  border: 1px solid rgba(2,6,23,0.08);
+}
+.dark .chip {
+  background: rgba(255,255,255,0.2);
+  color: rgb(226 232 240);
+  border-color: rgba(255,255,255,0.32);
+}
+
+/* Buttons */
+@layer components {
+  .btn {
+    display: inline-flex; align-items: center; justify-content: center;
+    gap: .5rem; padding: .6rem 1rem; border-radius: .8rem;
+    font-weight: 600; border: 1px solid rgba(2,6,23,0.08);
+    background: white; color: rgb(15 23 42);
+    /* let Tailwind shadow utilities handle box-shadow composition with rings */
+    position: relative;
+  }
+  .dark .btn { background: rgba(20,20,22,.9); color: rgb(226 232 240); border-color: rgba(255,255,255,.1); }
+}
+
+/* Explore-specific overrides removed; now purely utility-driven */

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}


### PR DESCRIPTION
- Summary: Modernized the UI across the site with a focus on dark‑mode readability, refined cards and search, and a more cohesive visual language. Added robust SEO metadata, sitemap generation, and Playwright tests with CI to keep things healthy going forward.

- Visual/UX
  - Dark mode: fixed low‑contrast areas (nav, hero, cards, tags, prompts) and unified tones.
  - Gallery: upgraded card design, readable tags, smoother hover states.
  - Search: toned input in dark mode, consistent chip styling.
  - Explore CTA: inverted in dark mode with subtle ring + outside glow (no inner fill).
  - Nav: improved legibility in dark mode while keeping rainbow underline.
  - System theme: removed manual toggle; respects system preference.

- Performance
  - `SearchClient` loads with `client:idle` on home to reduce initial main‑thread work.
  - Preconnects to Google Fonts for faster first paint.

- Accessibility
  - Adds `aria-current="page"` to active nav links for screen reader context.
  - Improved color contrasts in dark mode across components.

- SEO/Social
  - Global OG/Twitter tags in the layout (canonical, og:title/description/url/image).
  - Sref pages set `og:image` from the sref cover (fallback to first image).
  - Added `public/og.png` placeholder (replace with a designed 1200×630 later).
  - Added `@astrojs/sitemap` integration; `robots.txt` points to `sitemap-index.xml`.

- Testing/CI
  - Playwright setup with hover and pseudo‑element tests for the Explore button.
  - GitHub Actions workflow to run Playwright on push/PR with HTML report + traces on failure.

Notes
- Default OG image uses `public/og.png`. Recommend replacing with a branded 1200×630 asset.
- Sitemap uses default settings; we can tune changefreq/priority per route if desired.

How to test
- Build + preview: `npm run build && npm run preview`
- Visit: homepage (dark/light), sref detail pages, and ensure hover/rings work as expected.
- E2E: `npm run test:e2e` (runs Playwright; report uploaded in CI on failure).

No breaking changes expected; styles and behavior updated without changing public routes or data formats.
