### PR TITLE
fix: Use correct environment variable in transform-manifest script

### DIFF
--- a/scripts/transform-manifest.ts
+++ b/scripts/transform-manifest.ts
@@ -88,7 +88,7 @@ export async function transformManifest(): Promise<void> {
   const manifestPath = path.join(process.cwd(), 'dist', 'site.webmanifest');
   const config = createTransformConfig(
     process.env.PUBLIC_USE_CDN,
-    process.env.CLOUDFRONT_DOMAIN,
+    process.env.PUBLIC_CLOUDFRONT_DOMAIN,
     manifestPath
   );
   


### PR DESCRIPTION
## Summary
• Fix CI error where transform-manifest.ts was looking for `CLOUDFRONT_DOMAIN` but the CI workflow was setting `PUBLIC_CLOUDFRONT_DOMAIN`
• This caused the script to skip manifest transformation during CI builds with the message "CDN not enabled, skipping manifest transformation"

## Test plan
- [x] Verified script works with correct environment variable: `PUBLIC_USE_CDN=true PUBLIC_CLOUDFRONT_DOMAIN=d123.cloudfront.net`
- [x] Verified script skips when `PUBLIC_CLOUDFRONT_DOMAIN` is missing
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.ai/code)